### PR TITLE
My Rocket Ship Coding Challenge solution

### DIFF
--- a/rocket-ship/src/routes/LaunchPad/components/LaunchPad.js
+++ b/rocket-ship/src/routes/LaunchPad/components/LaunchPad.js
@@ -1,14 +1,8 @@
-import { useEffect, useState } from 'react';
 import { ClassRocket, FunctionalRocket } from './Rocket';
 import '../styles/_launchpad.scss';
 
 export default function LaunchPad() {
-  const [, triggerRerender] = useState(Date.now());
-  
-  useEffect(() => {
-    setInterval(() => { triggerRerender(Date.now()); }, 500);
-  }, [])
-  
+  // Rocket never launches, so prevent re-render by removing useEffect
   return (
     <div className="launchpad">
       <FunctionalRocket />

--- a/rocket-ship/src/routes/LaunchPad/components/Rocket/components/Rocket.js
+++ b/rocket-ship/src/routes/LaunchPad/components/Rocket/components/Rocket.js
@@ -1,8 +1,11 @@
 import React, { useState, Component } from 'react';
 import RocketCore from './RocketCore';
 
+const TEN_SECONDS_IN_MS = 10000; // In milliseconds
+
 export function FunctionalRocket() {
-  const [initialLaunchTime] = useState(Date.now());
+  // Launch time is 10 seconds in past, so never launches
+  const [initialLaunchTime] = useState(Date.now() - TEN_SECONDS_IN_MS);
 
   return <RocketCore initialLaunchTime={initialLaunchTime} />;
 }
@@ -12,7 +15,8 @@ export class ClassRocket extends Component {
     super(props);
 
     this.state = {
-      initialLaunchTime: Date.now()
+      // Launch time is 10 seconds in past, so never launches
+      initialLaunchTime: Date.now() - TEN_SECONDS_IN_MS
     };
   }
 


### PR DESCRIPTION
My solution for the following challenge: https://github.com/alexgurr/react-coding-challenges/tree/master/rocket-ship

On page load, the rocket launch time is set to be 10 seconds in the past, so never launches.

Considering:
> How we prevent components from re-rendering

As the rocket never launches, the `useEffect()` in `LaunchPad` no longer needs to trigger a re-render every 500 milliseconds, so removal of this prevents needless component re-rendering.